### PR TITLE
Implement Recognize

### DIFF
--- a/tesseract4android/src/main/cpp/tesseract/tessbaseapi.cpp
+++ b/tesseract4android/src/main/cpp/tesseract/tessbaseapi.cpp
@@ -752,6 +752,15 @@ jboolean Java_com_googlecode_tesseract_android_TessBaseAPI_nativeAddPageToDocume
   return JNI_TRUE;
 }
 
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_googlecode_tesseract_android_TessBaseAPI_nativeRecognize(JNIEnv *env, jobject thiz,
+                                                                  jlong mNativeData) {
+    native_data_t *nat = (native_data_t*) mNativeData;
+    nat->api.Recognize(nullptr);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/tesseract4android/src/main/java/com/googlecode/tesseract/android/TessBaseAPI.java
+++ b/tesseract4android/src/main/java/com/googlecode/tesseract/android/TessBaseAPI.java
@@ -716,6 +716,14 @@ public class TessBaseAPI {
 		return text != null ? text.trim() : null;
 	}
 
+	@WorkerThread
+	public void recognize() {
+		if (mRecycled)
+			throw new IllegalStateException();
+
+		nativeRecognize(mNativeData);
+	}
+
 	/**
 	 * Returns text where items on the given iterator level (symbol, word, line, paragraph, block)
 	 * which has confidence lower than given threshold are filtered out.
@@ -1218,4 +1226,6 @@ public class TessBaseAPI {
 	private native boolean nativeEndDocument(long rendererPointer);
 
 	private native boolean nativeAddPageToDocument(long mNativeData, long nativePix, String imagePath, long rendererPointer);
+
+	private native void nativeRecognize(long mNativeData);
 }


### PR DESCRIPTION
Calling `recognize` on the iterator instead of `getHOCRText` is ~20% faster for my test cases.

Image 1

| Test | Recognize() (ms) | GetHOCRText() (ms) |
|------|------------------|--------------------|
| 1    | 1366             | 1718               |
| 2    | 1116             | 1242               |
| 3    | 1048             | 1239               |
| **Average** | **1177**     | **1400**           |

Image 2

| Test | Recognize() (ms) | GetHOCRText() (ms) |
|------|------------------|--------------------|
| 1    | 878              | 1603               |
| 2    | 929              | 1201               |
| 3    | 1396             | 1132               |
| **Average** | **1068**     | **1312**           |