### PR TITLE
Upgrade NDK from r27 to r29 for 16 KB page size support

### DIFF
--- a/tesseract4android/build.gradle
+++ b/tesseract4android/build.gradle
@@ -6,7 +6,7 @@ plugins {
 android {
 	namespace 'cz.adaptech.tesseract4android'
 	compileSdk 35
-	ndkVersion "27.2.12479018"
+	ndkVersion "29.0.14206865"
 
 	defaultConfig {
 		minSdk 21
@@ -19,9 +19,7 @@ android {
 				// TODO: Include eyes-two in some build flavor of the library?
 				//targets "jpeg", "pngx", "leptonica", "tesseract"
 
-				// Support 16 KB page sizes with NDK r27
-				// This can be removed with NDK r28, which supports it by default.
-				arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+				// 16 KB page size support is enabled by default since NDK r28.
 			}
 		}
 		ndk {

--- a/tesseract4android/src/main/cpp/leptonica/CMakeLists.txt
+++ b/tesseract4android/src/main/cpp/leptonica/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # Sets the minimum version of CMake required to build the native library.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.10.0)
 
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.

--- a/tesseract4android/src/main/cpp/libjpeg/CMakeLists.txt
+++ b/tesseract4android/src/main/cpp/libjpeg/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # Sets the minimum version of CMake required to build the native library.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.10.0)
 
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.

--- a/tesseract4android/src/main/cpp/libpng/CMakeLists.txt
+++ b/tesseract4android/src/main/cpp/libpng/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # Sets the minimum version of CMake required to build the native library.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.10.0)
 
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.

--- a/tesseract4android/src/main/cpp/tesseract/CMakeLists.txt
+++ b/tesseract4android/src/main/cpp/tesseract/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # Sets the minimum version of CMake required to build the native library.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.10.0)
 
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.


### PR DESCRIPTION
## Summary

Upgrade the NDK version from `27.2.12479018` (r27b) to `29.0.14206865` (r29) to resolve the Google Play Console warning about apps not being compiled with NDK >= r28.

## Background

Google Play Console shows a warning when apps are built with NDK versions older than r28, because Android 15+ supports [16 KB page sizes](https://developer.android.com/guide/practices/page-sizes) and native libraries need to be compatible. NDK r27 added opt-in 16 KB support via the `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` CMake argument; **NDK r28 enables 16 KB page size support by default**, making that argument unnecessary.

## Changes

1. **`tesseract4android/build.gradle`**:
   - Bump `ndkVersion` from `27.2.12479018` → `29.0.14206865` (NDK r29 stable)
   - Remove the explicit `-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON` argument and its now-obsolete comment, since 16 KB page size support is enabled by default since NDK r28 (per the [r28 changelog](https://github.com/android/ndk/wiki/Changelog-r28#announcements))

2. **`tesseract4android/src/main/cpp/{leptonica,libjpeg,libpng,tesseract}/CMakeLists.txt`** (4 files):
   - Bump `cmake_minimum_required` from `3.4.1` → `3.10.0`, matching the minimum CMake version required by the NDK r28+ toolchain file (per [r28 changelog issue #2100](https://github.com/android/ndk/issues/2100))

## Verification

- ✅ Build succeeds: `./gradlew :tesseract4android:assembleStandardRelease` completes with `BUILD SUCCESSFUL`
- ✅ All `arm64-v8a` native libraries (`libjpeg.so`, `libpngx.so`, `libleptonica.so`, `libtesseract.so`) are **aligned to 16 KB** (verified with Google's [`check_elf_alignment.sh`](https://developer.android.com/guide/practices/page-sizes#check-alignment) script — all report `ALIGNED (2**14)`)
- ✅ No new build errors or warnings introduced by the NDK bump (only pre-existing `-Wunused-result` warnings in leptonica)

## References

- [NDK r28 changelog](https://github.com/android/ndk/wiki/Changelog-r28) — 16 KB page size support enabled by default
- [NDK r29 changelog](https://github.com/android/ndk/wiki/Changelog-r29)
- [NDK downloads](https://github.com/android/ndk/wiki) — r29 stable version: `29.0.14206865`
- [16 KB page sizes | Android Developers](https://developer.android.com/guide/practices/page-sizes)